### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Arduino-AD57X1
+version=0.0.0
+author=Patrick Baus
+maintainer=Patrick Baus
+sentence=For the Analog Devices AD5781/AD5791 18-/20-bit precision DAC
+paragraph=
+category=Signal Input/Output
+url=https://github.com/PatrickBaus/Arduino-AD57X1
+architectures=*
+includes=ad57X1.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the `src` subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for [inclusion in the Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata